### PR TITLE
Add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: PR Docker Build and Run Test
+run-name: ${{ github.actor }} is testing the building and run of Dockerfile on PR ${{ github.event.number }}
+on: [pull_request]
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Build Camera AMD64 Docker
+        run: docker build -t camera -f ./docker/amd64/cuda/camera.Dockerfile .
+      - name: Build Hydrus AMD64 Docker
+        run: docker build -t hydrus -f ./docker/amd64/cpu/hydrus.Dockerfile .
+      - name: Run catkin_make on Hydrus AMD64 Docker
+        run: sudo docker run --rm -i -v .:/home/catkin_ws/src hydrus bash -c "cd /home/catkin_ws && catkin_make"


### PR DESCRIPTION
Sorry for taking so long 🥲 Esto incluye lo de CI de github actions, para probar los PRs cada vez que alguien suba uno o modifique uno. Si quieren que cambie algo de los dockers que se están probando me avisan, pero entiendo que no se puede hacer crosscompilation en docker so los de la jetson se quedan sin probar sadly.